### PR TITLE
Add custom root for prepended commands.

### DIFF
--- a/features/vagrant-exec.feature
+++ b/features/vagrant-exec.feature
@@ -164,6 +164,21 @@ Feature: vagrant-exec
     Then the exit status should not be 0
     And the output should contain "prepend_with :only should be an array"
 
+  Scenario: can use custom root in prepend command
+    Given I overwrite "Vagrantfile" with:
+      """
+      $LOAD_PATH.unshift File.expand_path('../../../lib', __FILE__)
+      require 'vagrant-exec'
+
+      Vagrant.configure('2') do |config|
+        config.vm.box = 'vagrant_exec'
+        config.exec.prepend_with 'echo vagrant-exec &&', :only => %w(pwd echo), :root => '/tmp'
+      end
+      """
+    And I run `bundle exec vagrant up`
+    When I run `bundle exec vagrant exec pwd`
+    Then SHH subprocess should execute command "cd /tmp && echo vagrant-exec && pwd"
+
   Scenario: can export environment variables
     Given I overwrite "Vagrantfile" with:
       """

--- a/lib/vagrant-exec/command.rb
+++ b/lib/vagrant-exec/command.rb
@@ -72,6 +72,8 @@ module VagrantPlugins
         ''.tap do |cmd|
           prepends.each do |prep|
             if !prep[:only] || prep[:only].include?(bin)
+              custom_root = prep[:root].strip
+              cmd << "cd #{custom_root} && " if custom_root
               prep = prep[:command].strip # remove trailing space
               cmd << "#{prep} "
             end

--- a/lib/vagrant-exec/config.rb
+++ b/lib/vagrant-exec/config.rb
@@ -29,6 +29,9 @@ module VagrantPlugins
           if !@prepend_with.all? { |p| !p[:only] || p[:only].is_a?(Array) }
             return { 'exec' => ['prepend_with :only should be an array'] }
           end
+          if !@prepend_with.all? { |p| !p[:root] || p[:root].is_a?(String) }
+            return { 'exec' => ['prepend_with :root should be a string'] }
+          end
         end
 
         {}


### PR DESCRIPTION
I have a project that consists of several parts written in different programming languages(Ruby & Go)​​. Each part performs a specific function.
One part is written in Ruby (RoR) - main. It located in folder `/vagrant/web`. I need to add a prepend_with to vagrant-exec config to start the unicorn server.

``` ruby
config.exec.prepend_with 'bundle exec', only: %w(unicorn rails rake)
```

The second part - the worker is written in Go (go-workers). They are located in a different folder (`/vagrant/workers`). For them it is necessary to pass environment variables (GOROOT=`pwd`) and do not need to perform `bundle exec`
So I decided to add an extra parameter 'root' to each 'prepend_with' config.
