### PR TITLE
Allow an ssh host other than default for binstubs

### DIFF
--- a/features/vagrant-exec/binstubs.feature
+++ b/features/vagrant-exec/binstubs.feature
@@ -43,6 +43,24 @@ Feature: vagrant-exec binstubs
     Then the exit status should be 0
     And the output should contain "/vagrant"
 
+  Scenario: writes the ssh host from the defined vm
+    Given I write to "Vagrantfile" with:
+      """
+      Vagrant.configure('2') do |config|
+        config.vm.box = 'vagrant_exec'
+        config.vm.define 'vagrant'
+        config.exec.commands 'echo', directory: '/tmp'
+      end
+      """
+    And I run `bundle exec vagrant up`
+    When I run `bundle exec vagrant exec --binstubs`
+    And the file "bin/echo" should contain exactly:
+      """
+      #!/bin/bash
+      ssh -F .vagrant/ssh_config -q -t vagrant "bash -l -c 'cd /tmp && echo $@'"
+
+      """
+
   Scenario: dumps vagrant ssh-config to file
     Given I write to "Vagrantfile" with:
       """

--- a/lib/vagrant-exec/command.rb
+++ b/lib/vagrant-exec/command.rb
@@ -93,6 +93,7 @@ module VagrantPlugins
             command[:constructed].gsub!('"', '\"') # escape double-quotes
 
             variables = {
+              ssh_host: vm.name || 'default',
               ssh_config: SSH_CONFIG,
               shell: shell,
               command: command[:constructed],

--- a/lib/vagrant-exec/templates/binstub.erb
+++ b/lib/vagrant-exec/templates/binstub.erb
@@ -1,2 +1,2 @@
 #!/bin/bash
-ssh -F <%= ssh_config %> -q -t default "<%= shell %> -c '<%= command %> $@'"
+ssh -F <%= ssh_config %> -q -t <%= ssh_host %> "<%= shell %> -c '<%= command %> $@'"


### PR DESCRIPTION
The `binstub.erb` template assumes the `ssh host` will be `default`. This becomes problematic, if one's `Vagrantfile` is set up using `config.vm.define` like so:

```ruby
VAGRANTFILE_API_VERSION = '2'

Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.define 'box1' do
    ...
  end
end
```

We get a `vagrant ssh-config` of something like:

```
Host box1
  HostName 127.0.0.1
  User vagrant
  Port 2222
  ...
```

This commit changes the `default`, to a variable that is set to `vm.name`, which should be `default` by default.

This can be compatible with multi-vms, when one of the vm's passes `primary: true`, as shown:

```ruby
VAGRANTFILE_API_VERSION = '2'

Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.define 'box1', primary: true do
    ...
  end

  config.vm.define 'box2'
end
```

Thanks, this is very useful plugin!